### PR TITLE
feat(links): add prefix match support for associated links

### DIFF
--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -140,6 +140,8 @@ export const en = {
     'link_styles_toggle_desc': 'Replaces URLs in pills with the style name, keeping the native link click behavior.',
     'link_url_title': 'Associated Link',
     'link_url_placeholder': 'Enter a URL\u2026',
+    'prefix_match_title': 'Prefix match',
+    'prefix_match_desc': 'When enabled, any URL starting with this value will match (case-insensitive).',
     // UI Components
     'ui_components_title': 'Other styles',
     'ui_components_desc': 'Enable or disable visual components for the tags.',

--- a/src/lang/es.ts
+++ b/src/lang/es.ts
@@ -141,6 +141,8 @@ export const es = {
     'link_styles_toggle_desc': 'Reemplaza las URL en las píldoras por el nombre del estilo, manteniendo el comportamiento de clic nativo.',
     'link_url_title': 'Enlace asociado',
     'link_url_placeholder': 'Ingresa una URL\u2026',
+    'prefix_match_title': 'Coincidencia por prefijo',
+    'prefix_match_desc': 'Cuando está habilitado, cualquier URL que comience con este valor coincidirá (sin distinción de mayúsculas y minúsculas).',
     // UI Components
     'ui_components_title': 'Otros estilos',
     'ui_components_desc': 'Habilita o deshabilita componentes visuales de las etiquetas.',

--- a/src/lang/fr.ts
+++ b/src/lang/fr.ts
@@ -140,6 +140,8 @@ export const fr = {
     'link_styles_toggle_desc': 'Remplace les URL dans les pilules par le nom du style, en conservant le comportement de clic natif du lien.',
     'link_url_title': 'Lien associé',
     'link_url_placeholder': 'Entrez une URL…',
+    'prefix_match_title': 'Correspondance par préfixe',
+    'prefix_match_desc': 'Lorsqu\'activé, toute URL commençant par cette valeur correspondra (insensible à la casse).',
     // UI Components
     'ui_components_title': 'Autres styles',
     'ui_components_desc': 'Activer ou désactiver les composants visuels des étiquettes.',

--- a/src/lang/pt-BR.ts
+++ b/src/lang/pt-BR.ts
@@ -141,6 +141,8 @@ export const ptBR = {
     'link_styles_toggle_desc': 'Substitui URLs nas pílulas pelo nome do estilo, mantendo o clique nativo do link.',
     'link_url_title': 'Link associado',
     'link_url_placeholder': 'Insira uma URL\u2026',
+    'prefix_match_title': 'Correspondência por prefixo',
+    'prefix_match_desc': 'Quando ativado, qualquer URL que comece com este valor será correspondido (sem distinção de maiúsculas e minúsculas).',
     // UI Components
     'ui_components_title': 'Outros estilos',
     'ui_components_desc': 'Ative ou desative os componentes visuais das tags.',

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -140,6 +140,8 @@ export const zhCN = {
     'link_styles_toggle_desc': '将药丸中的 URL 替换为样式名称，同时保留原生的链接点击行为。',
     'link_url_title': '关联链接',
     'link_url_placeholder': '输入网址…',
+    'prefix_match_title': '前缀匹配',
+    'prefix_match_desc': '启用后，以该网址开头的任意链接都会匹配（忽略大小写）。',
     // UI Components
     'ui_components_title': '其他样式',
     'ui_components_desc': '启用或禁用标签的视觉组件。',

--- a/src/managers/style-manager.ts
+++ b/src/managers/style-manager.ts
@@ -11,6 +11,9 @@ export class StyleManager {
     private globalFallbackMap = new Map<string, string>();
     // Display info cache: className → { name, hasMatchValue }
     private styleInfoMap = new Map<string, { name: string; hasMatchValue: boolean }>();
+    // Prefix match styles, sorted longest-first for best-match priority
+    private prefixScopedList: { prefix: string; prop: string; classString: string }[] = [];
+    private prefixGlobalList: { prefix: string; classString: string }[] = [];
 
     constructor(plugin: TypifyPlugin) {
         this.plugin = plugin;
@@ -24,6 +27,8 @@ export class StyleManager {
         this.fastLookupMap.clear();
         this.globalFallbackMap.clear();
         this.styleInfoMap.clear();
+        this.prefixScopedList = [];
+        this.prefixGlobalList = [];
 
         if (this.styleElement) {
             this.styleElement.remove();
@@ -96,8 +101,16 @@ export class StyleManager {
 
             const classString = isImage ? `${className} typify-is-image` : isEmoji ? `${className} typify-is-emoji` : className;
 
-            // Populate O(1) Dictionaries
-            if (style.appliesTo && style.appliesTo.length > 0) {
+            // Populate lookup structures
+            if (style.prefixMatch && style.matchValue) {
+                if (style.appliesTo && style.appliesTo.length > 0) {
+                    style.appliesTo.forEach(prop => {
+                        this.prefixScopedList.push({ prefix: valueKey, prop: prop.toLowerCase(), classString });
+                    });
+                } else {
+                    this.prefixGlobalList.push({ prefix: valueKey, classString });
+                }
+            } else if (style.appliesTo && style.appliesTo.length > 0) {
                 style.appliesTo.forEach(prop => {
                     this.fastLookupMap.set(`${valueKey}|${prop.toLowerCase()}`, classString);
                 });
@@ -211,12 +224,30 @@ body .${className} {
         const valLower = value.toLowerCase();
         const propLower = propertyKey.toLowerCase();
         
-        // 1. Exact match with scope
         const scopedMatch = this.fastLookupMap.get(`${valLower}|${propLower}`);
         if (scopedMatch) return scopedMatch;
 
-        // 2. Exact match global
-        return this.globalFallbackMap.get(valLower);
+        const globalMatch = this.globalFallbackMap.get(valLower);
+        if (globalMatch) return globalMatch;
+
+        let bestPrefix: string | undefined;
+        let bestLength = 0;
+
+        for (const entry of this.prefixScopedList) {
+            if (entry.prefix.length > bestLength && valLower.startsWith(entry.prefix) && entry.prop === propLower) {
+                bestPrefix = entry.classString;
+                bestLength = entry.prefix.length;
+            }
+        }
+
+        for (const entry of this.prefixGlobalList) {
+            if (entry.prefix.length > bestLength && valLower.startsWith(entry.prefix)) {
+                bestPrefix = entry.classString;
+                bestLength = entry.prefix.length;
+            }
+        }
+
+        return bestPrefix;
     }
 
     /**
@@ -274,5 +305,7 @@ body .${className} {
         this.fastLookupMap.clear();
         this.globalFallbackMap.clear();
         this.styleInfoMap.clear();
+        this.prefixScopedList = [];
+        this.prefixGlobalList = [];
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,13 @@
 
 export interface StatusStyle {
     name: string;
-    matchValue?: string; // Optional: Value used for matching instead of name (e.g., a URL). Display uses name.
+    matchValue?: string;
+    prefixMatch?: boolean;
     baseColor: string;
     icon: string;
-    appliesTo?: string[]; // Optional: List of properties this style applies to. If empty/undefined, applies to all.
-    shape?: 'pill' | 'rectangle' | 'flat'; // Optional: Visual shape. Default is 'pill'.
-    colorMode?: 'subtle' | 'solid'; // Optional: Color intensity. Default is 'subtle' (transparent).
+    appliesTo?: string[];
+    shape?: 'pill' | 'rectangle' | 'flat';
+    colorMode?: 'subtle' | 'solid';
 }
 
 export interface CustomStatusIconsSettings {

--- a/src/ui/StyleEditorModal.ts
+++ b/src/ui/StyleEditorModal.ts
@@ -29,6 +29,7 @@ export class StyleEditorModal extends Modal {
     private shape: 'pill' | 'rectangle' | 'flat' | '' = '';
     private colorMode: 'subtle' | 'solid' | '' = '';
     private matchValue = '';
+    private prefixMatch = true;
 
     // DOM references for live preview updates
     private previewPillLight: HTMLElement | null = null;
@@ -50,6 +51,7 @@ export class StyleEditorModal extends Modal {
             this.shape = editStyle.shape || 'pill';
             this.colorMode = editStyle.colorMode || 'subtle';
             this.matchValue = editStyle.matchValue || '';
+            this.prefixMatch = editStyle.prefixMatch !== false;
         }
     }
 
@@ -220,8 +222,6 @@ export class StyleEditorModal extends Modal {
                             this.icon = `favicon:${domain}`;
                             this.renderIconButton();
                             this.updatePreview();
-                            // Optional Notice, but UI changing is enough indication
-                            // new Notice(t('favicon_fetch_success').replace('{domain}', domain));
                         }
                         
                         btn.setDisabled(false);
@@ -229,6 +229,15 @@ export class StyleEditorModal extends Modal {
                     });
                 });
             }
+
+            new Setting(contentEl)
+                .setName(t('prefix_match_title'))
+                .setDesc(t('prefix_match_desc'))
+                .addToggle(toggle => toggle
+                    .setValue(this.prefixMatch)
+                    .onChange(value => {
+                        this.prefixMatch = value;
+                    }));
         }
 
         // ============================================================
@@ -481,9 +490,9 @@ export class StyleEditorModal extends Modal {
             icon: this.icon
         };
 
-        // Only add matchValue if set
         if (this.matchValue.trim()) {
             style.matchValue = this.matchValue.trim();
+            style.prefixMatch = this.prefixMatch;
         }
 
         // Only add appliesTo if scoped

--- a/src/ui/StyleManagerModal.ts
+++ b/src/ui/StyleManagerModal.ts
@@ -246,6 +246,9 @@ export class StyleManagerModal extends Modal {
         if (style.matchValue) {
             metaRow.createSpan({ text: ' \u00b7 ' });
             metaRow.createSpan({ text: t('link_url_title') });
+            if (style.prefixMatch !== false) {
+                metaRow.createSpan({ text: ` (${t('prefix_match_title')})` });
+            }
         }
 
         // Right section: action buttons


### PR DESCRIPTION
Add a per-style prefix match toggle (default: enabled) that allows matching any URL starting with the configured value for **Associated Links** feature, instead of requiring an exact match. 
This enables patterns like setting https://github.com to match all github.com URLs.


For example:
```yaml
---
url:
  - https://github.com/leike-dev/Obsidian-Typify
  - https://github.com/
---
```

BEFORE:
<img width="727" height="224" alt="image" src="https://github.com/user-attachments/assets/b71124a4-bc30-465f-ad4e-ecc069a0e7a7" />

AFTER:
<img width="727" height="143" alt="image" src="https://github.com/user-attachments/assets/a4ee229f-1c16-46d2-8c10-0707e05eecaa" />


There is a toggle under the `associated links` input box:
<img width="918" height="298" alt="image" src="https://github.com/user-attachments/assets/669af0e0-5b23-4970-8f7e-36a8dbcd64fd" />

If users want exact matching, they can still turn it off.
Though personally I think it would be more versatile if `github` could be applied to all the `github/xxx` links.

---

Matching priority: exact match > longest prefix match (scoped) >
longest prefix match (global). All matching is case-insensitive.

Includes translations for en, zh-CN, pt-BR, fr, es.