### PR TITLE
fix: apply prefix matching immediately after save

### DIFF
--- a/src/managers/dom-manager.ts
+++ b/src/managers/dom-manager.ts
@@ -163,7 +163,7 @@ export class DOMManager {
                                 mutation.attributeName === 'data-property-key' ||
                                 mutation.attributeName === 'class')
                         ) {
-                            return; 
+                            return;
                         }
                         processNode(mutation.target);
                     }
@@ -175,8 +175,22 @@ export class DOMManager {
             this.refreshProcessing();
         }));
 
-        this.plugin.registerEvent(this.plugin.app.workspace.on('active-leaf-change', () => {
-            this.refreshProcessing();
+        this.plugin.registerEvent(this.plugin.app.workspace.on('active-leaf-change', (leaf) => {
+            if (!leaf) return;
+
+            // Obsidian can keep inactive tabs as DeferredView instances. Wait for
+            // the newly active leaf to finish loading, then force one full pass so
+            // already-observed Bases/Canvas roots receive current style rules.
+            void leaf.loadIfDeferred()
+                .then(() => {
+                    this.refreshProcessing();
+                    this.reprocessAllPills();
+                })
+                .catch(() => {
+                    // The normal refresh path remains a safe fallback if the leaf
+                    // cannot be loaded for any reason.
+                    this.refreshProcessing();
+                });
         }));
 
         // Robust fallback for dynamic views like Canvas that lazy-load elements without triggering workspace events

--- a/src/managers/dom-manager.ts
+++ b/src/managers/dom-manager.ts
@@ -206,6 +206,8 @@ export class DOMManager {
      * This is useful when settings/styles change and we need to update classes (e.g. adding typify-is-image).
      */
     reprocessAllPills() {
+        if (!this.observer) return;
+
         // 1. Reprocess all currently styled pills (in case their style changed or was removed)
         activeDocument.body.findAll('.custom-status-icon-pill').forEach(pill => {
             const propertyKey = pill.getAttribute('data-property-key');

--- a/src/managers/dom-manager.ts
+++ b/src/managers/dom-manager.ts
@@ -206,14 +206,16 @@ export class DOMManager {
             }
         });
 
-        // 2. Process any unstyled pills that might now match a newly imported or modified style
-        activeDocument.body.findAll('[data-typify-observed]').forEach(container => {
-            if (container.classList.contains('metadata-container')) {
-                this.processMetadataContainer(container);
-            } else if (container.classList.contains('bases-view')) {
-                this.processBasesView(container);
-                this.processBasesCardsView(container);
-            }
+        // 2. Re-scan all currently rendered roots so previously unstyled values
+        // can become matches immediately after a style rule changes. This must not
+        // depend on the observer bookkeeping marker: settings can change while a
+        // root is rendered but not yet marked as observed.
+        activeDocument.body.findAll('.metadata-container').forEach(container => {
+            this.processMetadataContainer(container);
+        });
+        activeDocument.body.findAll('.bases-view').forEach(view => {
+            this.processBasesView(view);
+            this.processBasesCardsView(view);
         });
     }
 

--- a/src/managers/style-manager.ts
+++ b/src/managers/style-manager.ts
@@ -98,8 +98,9 @@ export class StyleManager {
 
             const classString = isImage ? `${className} typify-is-image` : isEmoji ? `${className} typify-is-emoji` : className;
 
-            // Populate lookup structures
-            if (style.prefixMatch && style.matchValue) {
+            // Prefix matching was introduced as enabled by default. Treat legacy
+            // styles without an explicit prefixMatch value the same way as the UI.
+            if (style.prefixMatch !== false && style.matchValue) {
                 if (style.appliesTo && style.appliesTo.length > 0) {
                     style.appliesTo.forEach(prop => {
                         this.prefixScopedList.push({ prefix: valueKey, prop: prop.toLowerCase(), classString });


### PR DESCRIPTION
## What changed

- Reprocess all currently rendered Metadata and Bases roots after style/settings changes instead of relying on the internal `data-typify-observed` marker.
- When the active leaf changes, wait for `leaf.loadIfDeferred()` and then reprocess the newly visible DOM so Bases/Canvas that were inactive receive the current prefix-match state without requiring the user to toggle Properties or reopen the view.
- Treat an omitted `prefixMatch` value as enabled, matching the original feature semantics and the editor UI (`prefixMatch !== false`).

## Root cause

Prefix matching itself is persisted and the style cache is rebuilt on save. The remaining problem is view lifecycle.

A URL that did not match before enabling prefix matching can remain unstyled. `reprocessAllPills()` previously only found newly eligible values through roots carrying the internal `data-typify-observed` marker. In addition, inactive Obsidian tabs may be represented as `DeferredView` instances and finish rendering only when they become visible.

That explains the observed behavior: switching back to a Base, opening/closing Properties, or reopening Canvas causes Obsidian to render/mutate the relevant DOM, after which Typify finally evaluates the new prefix rule.

The fix therefore does not make polling or MutationObserver more aggressive. It performs one full re-evaluation when settings are saved and one after a leaf becomes active and finishes deferred loading.

There was also a semantic mismatch for older/imported styles: the prefix-match feature was introduced as enabled by default and the editor treats an omitted value as enabled, while `StyleManager.buildCache()` previously treated `undefined` as disabled.

## Obsidian API rationale

Obsidian documents that inactive tabs can be `DeferredView` instances and recommends `leaf.loadIfDeferred()` when a plugin must modify a view without forcing every hidden leaf to load. This PR only calls it for the leaf that has just become active, preserving the deferred-view performance optimization for inactive tabs.

## Scope

This remains intentionally small. No MutationObserver configuration, polling cadence, startup flow, settings schema, or rendering architecture was changed.

Changed files:
- `src/managers/dom-manager.ts`
- `src/managers/style-manager.ts`

## Suggested manual test

1. Create an associated-link style with match value `https://github.com` and prefix matching OFF.
2. Put `https://github.com/Leike-Dev/Obsidian-Typify` in a target property and confirm it does not match.
3. Enable prefix matching and save.
4. In the currently visible Properties/Bases view, confirm the style applies without closing/reopening Properties.
5. Switch to an already-open Bases tab and confirm it updates when the tab becomes active, without opening/closing its Properties panel.
6. Switch to an already-open Canvas tab containing the same property and confirm it updates when the Canvas becomes active, without closing/reopening Canvas.
7. Disable prefix matching and repeat the same checks in reverse.
8. Repeat for Properties, Bases Table, and Bases Cards.

## Validation note

The branch is based directly on `main` and is currently 3 commits ahead / 0 behind. The assistant runtime cannot clone the repository or install dependencies because outbound GitHub access is unavailable, so full `npm run build` / `npm run lint` still needs to be run locally before merge.

This PR remains a draft for local testing.