### PR TITLE
test: add automated coverage for prefix refresh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Automated tests
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+
+permissions:
+    contents: read
+
+jobs:
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+
+        steps:
+            - name: Check out repository
+              uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Run automated tests
+              run: npm test

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "version": "node dev/version-bump.mjs",
         "gen-icons": "node dev/generate-icons.mjs",
         "commit": "node dev/commit-helper.mjs",
-        "lint": "eslint ."
+        "lint": "eslint .",
+        "test": "node tests/run-tests.mjs"
     },
     "keywords": [],
     "author": "Flavio Azurita",

--- a/tests/dom-manager.test.mjs
+++ b/tests/dom-manager.test.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { setImmediate as waitForImmediate } from 'node:timers/promises';
+import { DOMManager } from '../src/managers/dom-manager';
+
+function restoreGlobal(name, descriptor) {
+    if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+    } else {
+        delete globalThis[name];
+    }
+}
+
+test('reprocessAllPills exits before touching the DOM after cleanup', () => {
+    const activeDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'activeDocument');
+    let activeDocumentReads = 0;
+
+    Object.defineProperty(globalThis, 'activeDocument', {
+        configurable: true,
+        get() {
+            activeDocumentReads += 1;
+            throw new Error('activeDocument must not be read after cleanup');
+        },
+    });
+
+    try {
+        const manager = Object.create(DOMManager.prototype);
+        manager.observer = null;
+
+        assert.doesNotThrow(() => manager.reprocessAllPills());
+        assert.equal(activeDocumentReads, 0);
+    } finally {
+        restoreGlobal('activeDocument', activeDocumentDescriptor);
+    }
+});
+
+test('reprocessAllPills scans every currently rendered root while active', () => {
+    const activeDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'activeDocument');
+    const selectors = [];
+    const processedPills = [];
+    const processedValues = [];
+    const processedMetadata = [];
+    const processedBases = [];
+    const processedCards = [];
+
+    const styledPill = { getAttribute: () => 'status' };
+    const styledValue = { getAttribute: () => 'status' };
+    const metadataContainer = {};
+    const basesView = {};
+
+    const elementsBySelector = new Map([
+        ['.custom-status-icon-pill', [styledPill]],
+        ['.custom-status-icon-value', [styledValue]],
+        ['.metadata-container', [metadataContainer]],
+        ['.bases-view', [basesView]],
+    ]);
+
+    Object.defineProperty(globalThis, 'activeDocument', {
+        configurable: true,
+        value: {
+            body: {
+                findAll(selector) {
+                    selectors.push(selector);
+                    return elementsBySelector.get(selector) ?? [];
+                },
+            },
+        },
+    });
+
+    try {
+        const manager = Object.create(DOMManager.prototype);
+        manager.observer = {};
+        manager.processPill = (...args) => processedPills.push(args);
+        manager.processValueListElement = (...args) => processedValues.push(args);
+        manager.processMetadataContainer = (container) => processedMetadata.push(container);
+        manager.processBasesView = (view) => processedBases.push(view);
+        manager.processBasesCardsView = (view) => processedCards.push(view);
+
+        manager.reprocessAllPills();
+
+        assert.deepEqual(selectors, [
+            '.custom-status-icon-pill',
+            '.custom-status-icon-value',
+            '.metadata-container',
+            '.bases-view',
+        ]);
+        assert.deepEqual(processedPills, [[styledPill, 'status']]);
+        assert.deepEqual(processedValues, [[styledValue, 'status']]);
+        assert.deepEqual(processedMetadata, [metadataContainer]);
+        assert.deepEqual(processedBases, [basesView]);
+        assert.deepEqual(processedCards, [basesView]);
+    } finally {
+        restoreGlobal('activeDocument', activeDocumentDescriptor);
+    }
+});
+
+test('active leaf changes wait for deferred loading before reprocessing', async () => {
+    const mutationObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'MutationObserver');
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    let activeLeafHandler;
+
+    class MutationObserverMock {
+        disconnect() {}
+        observe() {}
+    }
+
+    Object.defineProperty(globalThis, 'MutationObserver', {
+        configurable: true,
+        value: MutationObserverMock,
+    });
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            setInterval: () => 1,
+        },
+    });
+
+    const plugin = {
+        app: {
+            workspace: {
+                on(eventName, handler) {
+                    if (eventName === 'active-leaf-change') {
+                        activeLeafHandler = handler;
+                    }
+                    return { eventName };
+                },
+            },
+        },
+        getTargetProperties: () => [],
+        registerEvent: () => {},
+        registerInterval: () => {},
+    };
+
+    try {
+        const manager = new DOMManager(plugin, {});
+        const order = [];
+
+        manager.refreshProcessing = () => order.push('refresh');
+        manager.reprocessAllPills = () => order.push('reprocess');
+        manager.init();
+
+        assert.equal(typeof activeLeafHandler, 'function');
+        order.length = 0;
+
+        activeLeafHandler({
+            loadIfDeferred() {
+                order.push('load');
+                return Promise.resolve();
+            },
+        });
+
+        assert.deepEqual(order, ['load']);
+        await waitForImmediate();
+        assert.deepEqual(order, ['load', 'refresh', 'reprocess']);
+
+        order.length = 0;
+        activeLeafHandler({
+            loadIfDeferred() {
+                order.push('load');
+                return Promise.reject(new Error('deferred load failed'));
+            },
+        });
+
+        await waitForImmediate();
+        assert.deepEqual(order, ['load', 'refresh']);
+    } finally {
+        restoreGlobal('MutationObserver', mutationObserverDescriptor);
+        restoreGlobal('window', windowDescriptor);
+    }
+});

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -1,0 +1,91 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import process from 'node:process';
+import { build } from 'esbuild';
+
+const normalizePath = (path) => path.replaceAll('\\', '/');
+
+const testMocks = {
+    name: 'typify-test-mocks',
+    setup(context) {
+        context.onResolve({ filter: /^obsidian$/ }, () => ({
+            path: 'obsidian',
+            namespace: 'typify-test-mocks',
+        }));
+        context.onLoad({ filter: /^obsidian$/, namespace: 'typify-test-mocks' }, () => ({
+            contents: 'export const getIcon = () => null;',
+            loader: 'js',
+        }));
+
+        context.onResolve({ filter: /^\.\.\/main$/ }, (args) => {
+            const importer = normalizePath(args.importer);
+            if (
+                importer.endsWith('/src/managers/dom-manager.ts') ||
+                importer.endsWith('/src/managers/style-manager.ts')
+            ) {
+                return {
+                    path: 'typify-main',
+                    namespace: 'typify-test-mocks',
+                };
+            }
+        });
+        context.onLoad({ filter: /^typify-main$/, namespace: 'typify-test-mocks' }, () => ({
+            contents: 'export default class TypifyPlugin {}',
+            loader: 'js',
+        }));
+
+        context.onResolve({ filter: /^\.\/style-manager$/ }, (args) => {
+            if (normalizePath(args.importer).endsWith('/src/managers/dom-manager.ts')) {
+                return {
+                    path: 'style-manager',
+                    namespace: 'typify-test-mocks',
+                };
+            }
+        });
+        context.onLoad({ filter: /^style-manager$/, namespace: 'typify-test-mocks' }, () => ({
+            contents: 'export class StyleManager {}',
+            loader: 'js',
+        }));
+    },
+};
+
+const outputDirectory = await mkdtemp(join(tmpdir(), 'typify-tests-'));
+let exitCode = 1;
+
+try {
+    await build({
+        absWorkingDir: process.cwd(),
+        entryPoints: [
+            'tests/dom-manager.test.mjs',
+            'tests/style-manager.test.mjs',
+        ],
+        bundle: true,
+        platform: 'node',
+        format: 'cjs',
+        outdir: outputDirectory,
+        outExtension: { '.js': '.cjs' },
+        sourcemap: 'inline',
+        logLevel: 'silent',
+        plugins: [testMocks],
+    });
+
+    const testFiles = (await readdir(outputDirectory))
+        .filter((filename) => filename.endsWith('.test.cjs'))
+        .sort()
+        .map((filename) => join(outputDirectory, filename));
+
+    const result = spawnSync(process.execPath, ['--test', ...testFiles], {
+        stdio: 'inherit',
+    });
+
+    if (result.error) throw result.error;
+    exitCode = result.status ?? 1;
+} catch (error) {
+    console.error(error);
+} finally {
+    await rm(outputDirectory, { recursive: true, force: true });
+}
+
+process.exitCode = exitCode;

--- a/tests/style-manager.test.mjs
+++ b/tests/style-manager.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { StyleManager } from '../src/managers/style-manager';
+
+function restoreGlobal(name, descriptor) {
+    if (descriptor) {
+        Object.defineProperty(globalThis, name, descriptor);
+    } else {
+        delete globalThis[name];
+    }
+}
+
+function installFakeStyleDocument() {
+    const createElDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'createEl');
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+
+    Object.defineProperty(globalThis, 'createEl', {
+        configurable: true,
+        value: (tagName) => {
+            assert.equal(tagName, 'style');
+            return {
+                id: '',
+                isConnected: false,
+                textContent: '',
+                remove() {
+                    this.isConnected = false;
+                },
+            };
+        },
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+        configurable: true,
+        value: {
+            head: {
+                appendChild(element) {
+                    element.isConnected = true;
+                    return element;
+                },
+            },
+        },
+    });
+
+    return () => {
+        restoreGlobal('createEl', createElDescriptor);
+        restoreGlobal('document', documentDescriptor);
+    };
+}
+
+function createStyle(overrides = {}) {
+    return {
+        name: 'GitHub',
+        matchValue: 'https://github.com',
+        appliesTo: ['link'],
+        icon: '',
+        baseColor: '#4078c0',
+        colorMode: 'subtle',
+        shape: 'pill',
+        ...overrides,
+    };
+}
+
+function createManager(styles) {
+    return new StyleManager({
+        settings: {
+            statusStyles: styles,
+        },
+    });
+}
+
+test('legacy styles with omitted prefixMatch keep prefix matching enabled', () => {
+    const restoreDocument = installFakeStyleDocument();
+    const manager = createManager([createStyle()]);
+
+    try {
+        manager.buildCache();
+
+        assert.equal(
+            manager.findMatchingClass('https://github.com/Leike-Dev/Obsidian-Typify', 'LINK'),
+            'typify-style-0',
+        );
+        assert.equal(
+            manager.findMatchingClass('https://github.com/Leike-Dev/Obsidian-Typify', 'other'),
+            undefined,
+        );
+    } finally {
+        manager.cleanup();
+        restoreDocument();
+    }
+});
+
+test('prefixMatch false keeps exact matching without accepting longer values', () => {
+    const restoreDocument = installFakeStyleDocument();
+    const manager = createManager([
+        createStyle({
+            prefixMatch: false,
+        }),
+    ]);
+
+    try {
+        manager.buildCache();
+
+        assert.equal(
+            manager.findMatchingClass('https://github.com', 'link'),
+            'typify-style-0',
+        );
+        assert.equal(
+            manager.findMatchingClass('https://github.com/Leike-Dev', 'link'),
+            undefined,
+        );
+    } finally {
+        manager.cleanup();
+        restoreDocument();
+    }
+});
+
+test('the longest matching prefix wins', () => {
+    const restoreDocument = installFakeStyleDocument();
+    const manager = createManager([
+        createStyle({
+            name: 'GitHub',
+            appliesTo: [],
+        }),
+        createStyle({
+            name: 'Typify repository',
+            matchValue: 'https://github.com/Leike-Dev',
+            appliesTo: [],
+        }),
+    ]);
+
+    try {
+        manager.buildCache();
+
+        assert.equal(
+            manager.findMatchingClass('https://github.com/Leike-Dev/Obsidian-Typify', 'link'),
+            'typify-style-1',
+        );
+    } finally {
+        manager.cleanup();
+        restoreDocument();
+    }
+});


### PR DESCRIPTION
## What changed

- Add an isolated test runner that bundles the TypeScript sources with the existing `esbuild` dependency and executes them with Node's native test runner.
- Add automated regression coverage for the DOM refresh lifecycle introduced by #8.
- Add automated coverage for prefix matching defaults, explicit opt-out, property scoping, and longest-prefix precedence.
- Run the test suite automatically for pull requests and pushes to `main`.

## Test coverage

### DOMManager

- Returns before touching `activeDocument` when the observer has been cleaned up.
- Reprocesses styled values plus every currently rendered Metadata and Bases root while active.
- Waits for `loadIfDeferred()` before refreshing and reprocessing an active leaf.
- Preserves the refresh-only fallback when deferred loading rejects.

### StyleManager

- Treats an omitted `prefixMatch` as enabled for legacy/imported styles.
- Keeps exact-only behavior when `prefixMatch` is explicitly disabled.
- Selects the longest matching prefix.

## Scope

This is a stacked test-only PR targeting `agent/fix-prefix-match-refresh`, the head branch of #8. It does not change files under `src/`, does not modify `package-lock.json`, and adds no dependencies.

Once #8 is merged, this PR can be retargeted to `main` before merge.
