### PR TITLE
refactor(settings): mover Gerenciar estilos para subpágina

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,6 @@
 import { PluginSettingTab, App, Setting, Notice, SettingDefinitionItem, setIcon } from 'obsidian';
 import { StyleEditorModal } from './ui/StyleEditorModal';
-import { StyleManagerModal } from './ui/StyleManagerModal';
+import { StyleManagerPage } from './ui/StyleManagerPage';
 import { ExportSettingsModal } from './ui/ExportSettingsModal';
 import { ImportSettingsModal } from './ui/ImportSettingsModal';
 import { PaletteModal } from './ui/PaletteModal';
@@ -154,15 +154,10 @@ export class CustomStatusIconsSettingTab extends PluginSettingTab {
                 },
                 // Manage Styles
                 {
+                    type: 'page' as const,
                     name: t('manage_styles_title'),
                     desc: t('manage_styles_desc'),
-                    render: (setting: Setting) => {
-                        setting.addButton(button => button
-                            .setButtonText(t('manage_styles_button'))
-                            .onClick(() => {
-                                new StyleManagerModal(this.app, this.plugin, () => { this.update(); }).open();
-                            }));
-                    }
+                    page: () => new StyleManagerPage(this.app, this.plugin)
                 },
                 // Other styles
                 {

--- a/src/styles/modals/_manager.css
+++ b/src/styles/modals/_manager.css
@@ -394,3 +394,20 @@
     display: flex;
     gap: var(--size-4-2);
 }
+
+/* --------------------------------------------------------------------------
+   Settings sub-page
+   -------------------------------------------------------------------------- */
+
+/* The settings page already owns scrolling. Let the style list participate in
+   that scroll instead of creating a nested 400px scroll area. */
+.typify-manager-page {
+    min-width: 0;
+}
+
+.typify-manager-page .typify-manager-list {
+    height: auto;
+    overflow: visible;
+    -webkit-mask-image: none;
+    mask-image: none;
+}

--- a/src/ui/StyleManagerModal.ts
+++ b/src/ui/StyleManagerModal.ts
@@ -1,28 +1,18 @@
 // ============================================================================
-// STYLE MANAGER MODAL — Orchestrates sub-components for managing styles
+// STYLE MANAGER MODAL — Modal host for the shared style manager view
 // ============================================================================
 
-import { App, Modal, Notice } from 'obsidian';
+import { App, Modal } from 'obsidian';
 import TypifyPlugin from '../main';
-import { StatusStyle } from '../types';
+import type { StatusStyle } from '../types';
 import { StyleEditorModal } from './StyleEditorModal';
 import { t } from '../lang/helpers';
-
-import { StyleManagerToolbar } from './manager/StyleManagerToolbar';
-import { StyleManagerFilters } from './manager/StyleManagerFilters';
-import { StyleManagerList } from './manager/StyleManagerList';
-import { StyleManagerBatchActions } from './manager/StyleManagerBatchActions';
-import { showDeleteConfirmation } from './manager/StyleDeleteConfirmation';
+import { StyleManagerView } from './manager/StyleManagerView';
 
 export class StyleManagerModal extends Modal {
     plugin: TypifyPlugin;
     private onClose_cb?: () => void;
-
-    private toolbar!: StyleManagerToolbar;
-    private filters!: StyleManagerFilters;
-    private list!: StyleManagerList;
-    private batchActions!: StyleManagerBatchActions;
-
+    private view!: StyleManagerView;
     private selectedScope = '__show_all__';
 
     constructor(app: App, plugin: TypifyPlugin, onClose?: () => void, initialScope?: string) {
@@ -34,72 +24,32 @@ export class StyleManagerModal extends Modal {
         }
     }
 
-    onOpen() {
+    onOpen(): void {
         const { contentEl } = this;
         contentEl.empty();
         contentEl.addClass('typify-manager-modal');
 
         this.setTitle(t('manage_styles_modal_title'));
 
-        // ── Toolbar (search + scope dropdown) ──────────────────────────
-        this.toolbar = new StyleManagerToolbar(
+        this.view = new StyleManagerView(
             contentEl,
-            this.plugin,
-            this.selectedScope,
-            { onChange: () => { this.refreshList(); } }
-        );
-
-        // ── Sort/filter chips ──────────────────────────────────────────
-        const chipsContainerEl = contentEl.createDiv({ cls: 'typify-sort-chips' });
-        this.filters = new StyleManagerFilters(
-            chipsContainerEl,
-            { onChange: () => { this.refreshList(); } }
-        );
-
-        // ── Count label ────────────────────────────────────────────────
-        const countEl = contentEl.createDiv({ cls: 'typify-manager-count' });
-
-        // ── Style list ─────────────────────────────────────────────────
-        const listContainerEl = contentEl.createDiv({ cls: 'typify-manager-list' });
-
-        this.list = new StyleManagerList(
-            listContainerEl,
-            countEl,
+            this.app,
             this.plugin,
             {
                 onEdit: (style, realIndex) => { this.openEditor(style, realIndex); },
                 onDuplicate: (style) => { this.openDuplicator(style); },
-                onDelete: (itemEl, realIndex) => { this.confirmDelete(itemEl, realIndex); },
-            }
+            },
+            this.selectedScope
         );
-
-        // ── Sort/filter initial render ─────────────────────────────────
-        this.filters.render();
-
-        // ── Batch hint ─────────────────────────────────────────────────
-        const batchHintEl = contentEl.createDiv({ cls: 'typify-manager-batch-hint' });
-        this.batchActions = new StyleManagerBatchActions(
-            batchHintEl,
-            this.app,
-            this.plugin,
-            {
-                onBatchCreated: () => {
-                    this.toolbar.populateScopeOptions();
-                    this.refreshList();
-                }
-            }
-        );
-
-        this.refreshList();
+        this.view.display();
     }
 
-    // ── Navigation ─────────────────────────────────────────────────────
-
     private openEditor(style: StatusStyle, realIndex: number): void {
-        const currentScope = this.toolbar.selectedScope;
+        const currentScope = this.view.selectedScope;
         const onCloseCb = this.onClose_cb;
-        this.onClose_cb = undefined;   // prevent close callback from firing
-        this.close();                   // close this manager before opening editor
+        this.onClose_cb = undefined;
+        this.close();
+
         new StyleEditorModal(
             this.app,
             this.plugin,
@@ -116,10 +66,11 @@ export class StyleManagerModal extends Modal {
     }
 
     private openDuplicator(style: StatusStyle): void {
-        const currentScope = this.toolbar.selectedScope;
+        const currentScope = this.view.selectedScope;
         const onCloseCb = this.onClose_cb;
         this.onClose_cb = undefined;
         this.close();
+
         new StyleEditorModal(
             this.app,
             this.plugin,
@@ -135,42 +86,8 @@ export class StyleManagerModal extends Modal {
         ).open();
     }
 
-    private confirmDelete(itemEl: HTMLElement, realIndex: number): void {
-        const style = this.plugin.settings.statusStyles[realIndex];
-        if (!style) return;
-
-        showDeleteConfirmation(itemEl, style.name, realIndex, {
-            onConfirm: (index) => {
-                void (async () => {
-                    const deleted = this.plugin.settings.statusStyles[index];
-                    this.plugin.settings.statusStyles.splice(index, 1);
-                    await this.plugin.saveSettings();
-                    if (deleted) {
-                        new Notice(t('style_deleted').replace('{name}', deleted.name));
-                    }
-                    this.toolbar.populateScopeOptions();
-                    this.refreshList();
-                })();
-            },
-            onCancel: () => { /* confirmation element already removed itself */ }
-        });
-    }
-
-    // ── Refresh ────────────────────────────────────────────────────────
-
-    private refreshList(): void {
-        this.list.render(
-            this.toolbar.getSearchFilter(),
-            this.toolbar.selectedScope,
-            this.filters.sortMode,
-            this.filters.activeFilters
-        );
-        this.batchActions.renderHint(this.toolbar.selectedScope);
-    }
-
-    onClose() {
-        const { contentEl } = this;
-        contentEl.empty();
+    onClose(): void {
+        this.contentEl.empty();
         this.onClose_cb?.();
     }
 }

--- a/src/ui/StyleManagerPage.ts
+++ b/src/ui/StyleManagerPage.ts
@@ -1,0 +1,81 @@
+// ============================================================================
+// STYLE MANAGER PAGE — Native Obsidian settings sub-page
+// ============================================================================
+
+import { App, SettingPage } from 'obsidian';
+import type TypifyPlugin from '../main';
+import type { StatusStyle } from '../types';
+import { t } from '../lang/helpers';
+import { StyleEditorModal } from './StyleEditorModal';
+import { StyleManagerView } from './manager/StyleManagerView';
+
+/**
+ * Hosts the style manager in the native navigable settings-page component.
+ *
+ * The editor remains a Modal, as recommended for multi-field validated forms.
+ * The page stays mounted underneath it, so saving or cancelling only refreshes
+ * the list and preserves the current search, filters, sorting, and scope.
+ */
+export class StyleManagerPage extends SettingPage {
+    private view: StyleManagerView | null = null;
+    private visible = false;
+
+    constructor(
+        private app: App,
+        private plugin: TypifyPlugin
+    ) {
+        super();
+        this.title = t('manage_styles_title');
+    }
+
+    display(): void {
+        this.visible = true;
+        this.containerEl.empty();
+        this.containerEl.addClass('typify-manager-page');
+
+        this.view = new StyleManagerView(
+            this.containerEl,
+            this.app,
+            this.plugin,
+            {
+                onEdit: (style, realIndex) => { this.openEditor(style, realIndex); },
+                onDuplicate: (style) => { this.openDuplicator(style); },
+            }
+        );
+        this.view.display();
+    }
+
+    hide(): void {
+        this.visible = false;
+        this.view = null;
+        this.containerEl.removeClass('typify-manager-page');
+        super.hide();
+    }
+
+    private openEditor(style: StatusStyle, realIndex: number): void {
+        new StyleEditorModal(
+            this.app,
+            this.plugin,
+            () => { this.refresh(); },
+            style,
+            realIndex,
+            () => { this.refresh(); }
+        ).open();
+    }
+
+    private openDuplicator(style: StatusStyle): void {
+        new StyleEditorModal(
+            this.app,
+            this.plugin,
+            () => { this.refresh(); },
+            style,
+            undefined,
+            () => { this.refresh(); }
+        ).open();
+    }
+
+    private refresh(): void {
+        if (!this.visible) return;
+        this.view?.refresh();
+    }
+}

--- a/src/ui/manager/StyleManagerView.ts
+++ b/src/ui/manager/StyleManagerView.ts
@@ -1,0 +1,126 @@
+// ============================================================================
+// STYLE MANAGER VIEW — Shared manager UI for modal and settings sub-page
+// ============================================================================
+
+import { App, Notice } from 'obsidian';
+import type TypifyPlugin from '../../main';
+import type { StatusStyle } from '../../types';
+import { t } from '../../lang/helpers';
+
+import { StyleManagerToolbar } from './StyleManagerToolbar';
+import { StyleManagerFilters } from './StyleManagerFilters';
+import { StyleManagerList } from './StyleManagerList';
+import { StyleManagerBatchActions } from './StyleManagerBatchActions';
+import { showDeleteConfirmation } from './StyleDeleteConfirmation';
+
+export interface StyleManagerViewCallbacks {
+    onEdit: (style: StatusStyle, realIndex: number) => void;
+    onDuplicate: (style: StatusStyle) => void;
+}
+
+/**
+ * Renders and coordinates the style manager independently from its host.
+ *
+ * The same view can live in a Modal (commands and external entry points) or in
+ * a SettingPage (the navigable entry in the Typify settings tab).
+ */
+export class StyleManagerView {
+    private toolbar!: StyleManagerToolbar;
+    private filters!: StyleManagerFilters;
+    private list!: StyleManagerList;
+    private batchActions!: StyleManagerBatchActions;
+
+    constructor(
+        private containerEl: HTMLElement,
+        private app: App,
+        private plugin: TypifyPlugin,
+        private callbacks: StyleManagerViewCallbacks,
+        private initialScope = '__show_all__'
+    ) {}
+
+    get selectedScope(): string {
+        return this.toolbar.selectedScope;
+    }
+
+    display(): void {
+        this.containerEl.empty();
+
+        this.toolbar = new StyleManagerToolbar(
+            this.containerEl,
+            this.plugin,
+            this.initialScope,
+            { onChange: () => { this.refreshList(); } }
+        );
+
+        const chipsContainerEl = this.containerEl.createDiv({ cls: 'typify-sort-chips' });
+        this.filters = new StyleManagerFilters(
+            chipsContainerEl,
+            { onChange: () => { this.refreshList(); } }
+        );
+
+        const countEl = this.containerEl.createDiv({ cls: 'typify-manager-count' });
+        const listContainerEl = this.containerEl.createDiv({ cls: 'typify-manager-list' });
+
+        this.list = new StyleManagerList(
+            listContainerEl,
+            countEl,
+            this.plugin,
+            {
+                onEdit: (style, realIndex) => { this.callbacks.onEdit(style, realIndex); },
+                onDuplicate: (style) => { this.callbacks.onDuplicate(style); },
+                onDelete: (itemEl, realIndex) => { this.confirmDelete(itemEl, realIndex); },
+            }
+        );
+
+        this.filters.render();
+
+        const batchHintEl = this.containerEl.createDiv({ cls: 'typify-manager-batch-hint' });
+        this.batchActions = new StyleManagerBatchActions(
+            batchHintEl,
+            this.app,
+            this.plugin,
+            { onBatchCreated: () => { this.refresh(); } }
+        );
+
+        this.refreshList();
+    }
+
+    /**
+     * Refreshes dynamic options and the list while preserving search, filters,
+     * sorting, and the selected scope.
+     */
+    refresh(): void {
+        this.toolbar.populateScopeOptions();
+        this.refreshList();
+    }
+
+    private confirmDelete(itemEl: HTMLElement, realIndex: number): void {
+        const style = this.plugin.settings.statusStyles[realIndex];
+        if (!style) return;
+
+        showDeleteConfirmation(itemEl, style.name, realIndex, {
+            onConfirm: (index) => {
+                void (async () => {
+                    const deleted = this.plugin.settings.statusStyles[index];
+                    this.plugin.settings.statusStyles.splice(index, 1);
+                    await this.plugin.saveSettings();
+                    if (deleted) {
+                        new Notice(t('style_deleted').replace('{name}', deleted.name));
+                    }
+                    this.refresh();
+                })();
+            },
+            onCancel: () => { /* confirmation element already removed itself */ }
+        });
+    }
+
+    private refreshList(): void {
+        this.list.render(
+            this.toolbar.getSearchFilter(),
+            this.toolbar.selectedScope,
+            this.filters.sortMode,
+            this.filters.activeFilters
+        );
+        this.batchActions.renderHint(this.toolbar.selectedScope);
+    }
+}


### PR DESCRIPTION
## Resumo

- transforma **Gerenciar estilos** em uma subpágina nativa de configurações, seguindo o mesmo padrão navegável usado por **Outros estilos**
- usa uma `SettingPage` imperativa porque a interface é dinâmica e combina pesquisa, filtros, lista e criação em lote
- mantém `StyleEditorModal` para criar, editar e duplicar estilos
- preserva `StyleManagerModal` para a Paleta de comandos e outros pontos de entrada fora das configurações
- extrai `StyleManagerView` para que modal e subpágina compartilhem exatamente a mesma lógica

## Comportamento do editor

Na subpágina, o editor abre como modal sobre as configurações. Ao salvar ou cancelar:

- a subpágina permanece aberta
- a lista é atualizada
- pesquisa, filtros, ordenação e escopo selecionado são preservados
- não há fechamento/reabertura encadeada de modais

Esse é o padrão recomendado pela documentação do Obsidian para listas cujas entradas precisam de um formulário modal com múltiplos campos e validação.

## Layout

Na subpágina, a lista deixa de criar uma área interna fixa de 400 px e passa a usar a rolagem da própria página de configurações. O modal independente mantém o comportamento anterior.

## Escopo

Arquivos alterados:

- `src/settings.ts`
- `src/styles/modals/_manager.css`
- `src/ui/StyleManagerModal.ts`
- `src/ui/StyleManagerPage.ts`
- `src/ui/manager/StyleManagerView.ts`

Nenhuma tradução ou formato de dados foi alterado.

## Teste manual sugerido

### Desktop

- abrir Configurações → Typify → Estilos → Gerenciar estilos
- pesquisar, filtrar e trocar o escopo
- editar um estilo, salvar e confirmar que a subpágina e seus filtros permanecem
- duplicar e cancelar
- excluir um estilo e usar a criação em lote
- abrir **Gerenciar estilos** pela Paleta de comandos e confirmar o modal independente

### Tablet e telefone

- confirmar a navegação nativa para a subpágina e o botão Voltar
- abrir o editor por cima, salvar e cancelar
- abrir o seletor de ícones a partir do editor
- confirmar que a rolagem pertence à página e não fica presa numa lista interna de 400 px
